### PR TITLE
Admin id is not hardcoded and can now accept multiple of them in a list inside private-data.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
+.vscode/
+
 *.pyc
 *.log
 private-data.json

--- a/bot.py
+++ b/bot.py
@@ -115,6 +115,7 @@ def reload_data(bot, update):
         logger.info("Reloading settings")
         load_settings()
         bot.send_message(chat_id=update.message.chat_id, text="Datos cargados")
+    delete_message(bot, update)
 
 
 def news_command(bot, update):

--- a/bot.py
+++ b/bot.py
@@ -42,6 +42,10 @@ def error_callback(bot, update, error):
     except TelegramError:
         logger.exception("There is some error with Telegram")
 
+def is_admin(user_id):
+    if user_id in settings.admin_ids:
+        return True
+    return False
 
 def get_schedule():
     with io.open('horarios.json', 'r', encoding='utf8') as data_file:
@@ -107,7 +111,7 @@ def human_texting(string):
 
 
 def reload_data(bot, update):
-    if update.message.from_user.id == 15360527:
+    if is_admin(update.message.from_user.id):
         logger.info("Reloading settings")
         load_settings()
         bot.send_message(chat_id=update.message.chat_id, text="Datos cargados")

--- a/data_loader.py
+++ b/data_loader.py
@@ -23,6 +23,7 @@ class DataLoader:
             self.help_string = data_and_settings["strings"]["help"]
             self.github_url = data_and_settings["strings"]["github_url"]
             self.admin_password = data_and_settings["admin_password"]
+            self.admin_ids = data_and_settings["admin_ids"]
             self.degrees = data_and_settings["degrees"]
             self.etsisi_urls = data_and_settings["etsisi_urls"]
             self.upm_jsons = data_and_settings["upm_jsons"]

--- a/private-data.example.json
+++ b/private-data.example.json
@@ -1,4 +1,5 @@
 {
     "telegram_token": "",
-    "admin_password": ""
+    "admin_password": "",
+    "admin_ids": []
 }


### PR DESCRIPTION
Eso.. bastante simple.

Se añade una función que coteja una id con una lista predefinida en el private-data. Además se hará más cómodo manejar comandos de admin en el futuro.

Además, el comando /reload se borra igual que cuando un comando esta rate-limited