### PR TITLE
Accepting days (lunes/L, martes/M, miércoles/X, etc..) as /horario argument

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -31,8 +31,8 @@ def error_callback(bot, update, error):
         raise error
     except Unauthorized:
         logger.exception("remove update.message.chat_id from conversation list")
-    except BadRequest:
-        if update.message.chat_id < 0:  # This pre-check is necessary if we do not want to spam the logs with "BadRequest: Message can't be deleted" as this bot has no power to remove user messages in private chats.
+    except BadRequest as e:
+        if update.message.chat_id < 0 and e == "Message can't be deleted":  # This pre-check is necessary if we do not want to spam the logs with "BadRequest: Message can't be deleted" as this bot has no power to remove user messages in private chats.
             logger.exception("handle malformed requests - read more below!")
     except TimedOut:
         logger.exception("handle slow connection problems")

--- a/bot.py
+++ b/bot.py
@@ -52,7 +52,16 @@ codedays = {
     "J": 3,
     "V": 4,
     "S": 5,
-    "D": 6
+    "D": 6,
+    "LUNES": 0,
+    "MARTES": 1,
+    "MIÉRCOLES": 2,
+    "MIERCOLES": 2,
+    "JUEVES": 3,
+    "VIERNES": 4,
+    "SÁBADO": 5,
+    "SABADO": 6,
+    "DOMINGO": 7,
 }
 
 def get_schedule():
@@ -183,18 +192,25 @@ def schedule_command(bot, update, args):  # Add arguments for checking other's g
             group = ""
             day_index = datetime.datetime.today().weekday()
             if args:
-                args = map(str.upper, map(str,args))
+                args = [str(x.upper()) for x in args]
                 if re.match(r"G[TM][1-4]{2}", args[0]):  # Either True or False
                     group = args[0]
-                    print group
-                    if re.match(r"[LMXJV]", args[1]):  # Two inputs: group and daycode
-                            day_index = codedays[args[1]]
+                    print args
+                    if len(args) > 1:  # If a second paramenter exists
+                        if re.match(r"[LMXJV]", args[1]) or args[1].decode('utf-8') in codedays.keys():  # Two inputs: group and daycode
+                                print args[1].decode('utf-8')
+                                day_index = codedays[str(args[1].decode('utf-8'))]
                 else:
-                    if not re.match(r"[LMXJV]", args[0]):  # Two inputs: group and daycode
-                        bot.send_message(chat_id=update.message.chat_id,
-                            text = "Día de la semana inválido. Debes introducir M, X, J, V")
-                        return
-                    day_index = codedays[args[0]]
+                    if not re.match(r"[LMXJV]", args[0]) or not args[0].decode('utf-8') in codedays.keys():  # Two inputs: group and daycode
+                            if update.message.chat_id < 0:
+                                bot.send_message(chat_id=update.message.chat_id,
+                                    text = "Día de la semana inválido. Debes introducir martes/M, miércoles/X, jueves/J, viernes/V")
+                                return
+                            else:
+                                bot.send_message(chat_id=update.message.chat_id,
+                                    text = "Debes especificar un grupo. <i>Por ejemplo: /horario gt11</i>", parse_mode=telegram.ParseMode.HTML)
+                                return
+                    day_index = codedays[str(args[0].decode('utf-8'))]
                     
             if update.message.chat_id < 0:  # ID's below 0 are groups.
                 group = update.message.chat.title.replace(" ETSISI", "")  # get group from chat title
@@ -205,15 +221,18 @@ def schedule_command(bot, update, args):  # Add arguments for checking other's g
                 bot.send_message(chat_id=update.message.chat_id, text=text)
             elif day_index == datetime.datetime.today().weekday():  # Check if user input is from 'today'
                 bot.send_message(chat_id=update.message.chat_id,
-                                 text="Hoy " + weekdays[day_index] + " no hay horario")
+                                 text="Hoy " + weekdays[day_index] + " no hay clases.")
+                return
             else:
                 bot.send_message(chat_id=update.message.chat_id,
-                                 text="El " + weekdays[day_index] + " no hay horario")
+                                 text="El " + weekdays[day_index] + " no hay clases.")
+                return
         except:
             tb = traceback.format_exc()
             bot.send_message(chat_id=update.message.chat_id,
                              text="No he podido procesar tu solicitud de horario.\n\nERROR:\n" + str(
                                  tb) + "\n\nPor favor, reenvía este error a @nestoroa.")
+            return
     else:
         delete_message(bot, update)
 

--- a/data.json
+++ b/data.json
@@ -1,6 +1,6 @@
 {
   "strings":{
-    "help": "Hola, soy el bot de utilidades para miembros de la ETSISI.\nTe puedo ayudar de muchas formas:\n\n·> /horario te mandará el horario de tu grupo. También puedes consultar horarios de otros días y grupos. <i>Ejemplo: /horario gt11 m</i>\n·> /noticias te devolverá las últimas noticias que aparezcan en la web de nuestra escuela\n·> /avisos te mandará los avisos importantes para alumnos\n·> /eventos Te mandará la lista de los próximos eventos de la escuela.\n\nMi código está en <a href=\"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot\">Github</a>. Todavía estoy en beta, ten paciencia conmigo :)",
+    "help": "Hola, soy el bot de utilidades para miembros de la ETSISI.\nTe puedo ayudar de muchas formas:\n\n·> /horario te mandará el horario de tu grupo. También puedes consultar horarios de otros días y grupos. <i>Ejemplo: /horario gt11 martes</i>\n·> /noticias te devolverá las últimas noticias que aparezcan en la web de nuestra escuela\n·> /avisos te mandará los avisos importantes para alumnos\n·> /eventos Te mandará la lista de los próximos eventos de la escuela.\n\nMi código está en <a href=\"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot\">Github</a>. Todavía estoy en beta, ten paciencia conmigo :)",
     "github_url":"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot"
   },
   "degrees": {

--- a/data.json
+++ b/data.json
@@ -1,6 +1,6 @@
 {
   "strings":{
-    "help": "Hola, soy el bot de utilidades para miembros de la ETSISI.\nTe puedo ayudar de muchas formas:\n\n·> /horario te mandará el horario de tu grupo.\n·> /noticias te devolverá las últimas noticias que aparezcan en la web de nuestra escuela\n·> /avisos te mandará los avisos importantes para alumnos\n·> /eventos Te mandará la lista de los próximos eventos de la escuela.\n\nMi código está en <a href=\"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot\">Github</a>. Todavía estoy en beta, ten paciencia conmigo :)",
+    "help": "Hola, soy el bot de utilidades para miembros de la ETSISI.\nTe puedo ayudar de muchas formas:\n\n·> /horario te mandará el horario de tu grupo. También puedes consultar horarios de otros días y grupos. <i>Ejemplo: /horario gt11 m</i>\n·> /noticias te devolverá las últimas noticias que aparezcan en la web de nuestra escuela\n·> /avisos te mandará los avisos importantes para alumnos\n·> /eventos Te mandará la lista de los próximos eventos de la escuela.\n\nMi código está en <a href=\"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot\">Github</a>. Todavía estoy en beta, ten paciencia conmigo :)",
     "github_url":"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot"
   },
   "degrees": {


### PR DESCRIPTION
El comando `/horario` ahora acepta hasta dos argumentos. En grupos se puede pedir el horario para cualquier día de la semana tal que `/horario X` (miércoles).

![image](https://user-images.githubusercontent.com/38569176/45304290-13278600-b518-11e8-9673-9ccf5f4f5435.png)

El argumento de grupo se tiene que especificar primero. En el caso en el que se espcifique un grupo en un chat de grupo se ignora, pero toma en cuenta el día.

Por privado:

![image](https://user-images.githubusercontent.com/38569176/45304663-d9a34a80-b518-11e8-95fd-a3c413b5d367.png)

