### PR TITLE
Añadido comando /calendario y /profesores

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,7 +1,8 @@
 {
   "strings":{
     "help": "Hola, soy el bot de utilidades para miembros de la ETSISI.\nTe puedo ayudar de muchas formas:\n\n·> /horario te mandará el horario de tu grupo. También puedes consultar horarios de otros días y grupos. <i>Ejemplo: /horario gt11 martes</i>\n·> /noticias te devolverá las últimas noticias que aparezcan en la web de nuestra escuela\n·> /avisos te mandará los avisos importantes para alumnos\n·> /eventos Te mandará la lista de los próximos eventos de la escuela.\n\nMi código está en <a href=\"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot\">Github</a>. Todavía estoy en beta, ten paciencia conmigo :)",
-    "github_url":"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot"
+    "github_url":"https://github.com/CoreDumped-ETSISI/etsisi-telegram-bot",
+    "calendar": "En el siguiente link encontrarás el <a href=\"https://www.etsisi.upm.es/sites/default/files/curso_2018_19/calendario_escolar.pdf\">Calendario Escolar</a>"
   },
   "degrees": {
     "Sistemas de Información": "61SI",

--- a/data_loader.py
+++ b/data_loader.py
@@ -23,6 +23,7 @@ class DataLoader:
             self.help_string = data_and_settings["strings"]["help"]
             self.github_url = data_and_settings["strings"]["github_url"]
             self.admin_password = data_and_settings["admin_password"]
+            self.calendar_string = data_and_settings["strings"]["calendar"]
             self.admin_ids = data_and_settings["admin_ids"]
             self.degrees = data_and_settings["degrees"]
             self.etsisi_urls = data_and_settings["etsisi_urls"]

--- a/profesores.json
+++ b/profesores.json
@@ -1,0 +1,109 @@
+{
+  "GM11": {
+    "AM" : "Alfonsa García López / Francisco García Mazarío",
+    "MD" : "Mª Teresa Foulquié Usán",
+    "FC" : "Adolfo Yela Ruiz",
+    "P" : "Belén Salazar Dutrús",
+    "TSO" : "José Ernesto Jiménez Merino / Andrés Sevilla de Pablo",
+    "TP" : "Belén Salazar Dutrús / Carmen Gil Abad"
+  },
+  "GM12": {
+    "AM" : "Gregoria Blanco Viejo / Alfonsa García López",
+    "MD" : "Mª Teresa Foulquié Usán / Aránzazu Corral Herrero",
+    "FC" : "Juan José Cuervas Mons-Elvira",
+    "P" : "Francisco Javier Sáenz Marcilla",
+    "TSO" : "Rosa Mª Pinero Fernández / Andrés Sevilla de Pablo",
+    "TP" : "Francisco Javier Sáenz Marcilla / Ángel Arroyo Castillo"
+  },
+  "GM13": {
+    "AM" : "Luis Miguel Pozo Coronado / Alfonsa García López",
+    "MD" : "Ángeles Martínez Sánchez",
+    "FC" : "Adolfo Yela Ruiz",
+    "P" : "Carmen Gil Abad ",
+    "TSO" : "José Ernesto Jiménez Merino / Andrés Sevilla de Pablo",
+    "TP" : "Carmen Gil Abad / Belén Salazar Dutrús"
+  },
+  "GM14": {
+    "AM" : "Alfonsa García López / Félix Rincón Rojas",
+    "MD" : "Ángeles Martínez Sánchez ",
+    "FC" : "José Gutiérrez Fernández",
+    "P" : "Carmen Gil Abad",
+    "TSO" : "Norberto Cañas de Paz / Andrés Sevilla de Pablo",
+    "TP" : "Carmen Gil Abad / Pilar Martínez García"
+  },
+  "GM15": {
+    "AM" : "Rafael Miñano Rubio / Félix Rincón de Rojas",
+    "MD" : "Jesús García López de Lacalle",
+    "FC" : "Juan Luis Martín Garcés",
+    "P" : "Ana Palomar Martín",
+    "TSO" : "Rosa María Pinero Fernández / Andrés Sevilla de Pablo",
+    "TP" : "Ana Palomar Martín / Francisco Javier Sáenz Marcilla"
+  },
+  "GT11": {
+	"AM" : "Francisco García Mazarío / Alfonsa García López",
+    "MD" : "José Ignacio Gómez Leal",
+    "FC" : "Bernardo Tabuenca Archilla",
+    "P" : "Belén Salazar Dutrús",
+    "TSO" : "Pedro Pablo López Rodríguez / Norberto Cañas de Paz",
+    "TP" : "Belén Salazar Dutrús / Pilar Martínez García"
+  },
+  "GT12": {
+    "AM" : "Francisco García Mazarío / Félix Rincón de Rojas",
+    "MD" : "José Juan Carreño Carreño / José Ignacio Gómez Leal",
+    "FC" : "Adolfo Yela Ruiz",
+    "P" : "Francisco Javier Sáenz Marcilla ",
+    "TSO" : "Pedro Pablo López Rodríguez / Andrés Sevilla de Pablo",
+    "TP" : "Francisco Javier Sáenz Marcilla / Ángel Arroyo Castillo"
+  },
+  "GT13": {
+    "AM" : "Rafael Miñano Rubio / Félix Rincón de Rojas",
+    "MD" : "José Juan Carreño Carreño",
+    "FC" : "Vicente García Alcántara",
+    "P" : "José Ramón Sánchez Couso",
+    "TSO" : "Pedro Pablo López Rodríguez / Andrés Sevilla de Pablo",
+    "TP" : "José Ramón Sánchez Couso / Fernando Arroyo Montoro"
+  },
+  "GT14": {
+    "AM" : "----",
+    "MD" : "----",
+    "FC" : "José Gutiérrez Fernández",
+    "P" : "José Ramón Sánchez Couso ",
+    "TSO" : "Pedro Pablo López Rodríguez / Andrés Sevilla de Pablo",
+    "TP" : "José Ramón Sánchez Couso / Fernando Arroyo Montoro"
+  },
+  "GM21": {
+    "AL" : "Antonio Hernando Esteban (teoría y practicas) / Miguel Ángel Díaz Martín (prácticas)",
+    "AC" : "Mª Teresa Foulquié Usán",
+    "BD" : "Concepción Martín Gascueña (T y P) / Edgar Talavera Muñoz (P)",
+    "IA" : "Javier de Lope Asiaín",
+    "POO" : "Abraham Gutiérrez Rodríguez"
+  },
+  "GM22": {
+    "AL" : "Antonio Hernando Esteban (teoría y practicas) / Miguel Ángel Díaz Martín (prácticas)",
+    "AC" : "Francisco Aylagas Romero",
+    "BD" : "Fernando Ortega Requena (T y P) / Concepción Martín Gascueña (P)",
+    "IA" : "J. Eugenio Naranjo Hernández",
+    "POO" : "Abraham Gutiérrez Rodríguez"
+  },
+  "GM23": {
+    "AL" : "Miguel Ángel Díaz Martín (teoría y practicas) / Antonio Hernando Esteban (prácticas)",
+    "AC" : "Francisco Aylagas Romero",
+    "BD" : "Concepción Martín Gascueña (T y P) / Edgar Talavera Muñoz (P)",
+    "IA" : "J. Eugenio Naranjo Hernández",
+    "POO" : "Jesús Bobadilla Sancho"
+  },
+  "GT21": {
+    "AL" : "Soledad Delgado Sanz (teoría y practicas) / Antonio Hernando Esteban (prácticas)",
+    "AC" : "Elvira Martínez de Icaya Gómez",
+    "BD" : "Francisco Javier Moldes Teo (T) / Eva Gil García (P) / Edgar Talavera Muñoz (P)",
+    "IA" : "Javier de Lope Asiaín",
+    "POO" : "Nuria Gómez Blas"
+  },
+  "GT22": {
+   "AL" : "Antonio Hernando Esteban (teoría y practicas) / Soledad Delgado Sanz (prácticas)",
+    "AC" : "José Luis Esteban de la Hermosa",
+    "BD" : "Francisco Javier Moldes Teo (T) / Eva Gil García (P)",
+    "IA" : "J. Eugenio Naranjo Hernández",
+    "POO" : "Jesús Bobadilla Sancho"
+  }
+}


### PR DESCRIPTION
Añadidos comandos:

- /calendario : Escribe un mensaje con el link al archivo pdf con el calendario escolar 2019/2019

- /profesores : Escribe los profesores del primer semestre del grupo de clase que lo esté utilizando. Por privado "/profesores grupo" contestará los profesores del grupo que sea introducido.